### PR TITLE
Fix editor centering

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -314,6 +314,7 @@ body {
     /* Em vez disso, confiamos no justify-content: center do PARENT (.paper-container)
        e garantimos que este item seja centralizável como um flex-item */
     align-self: center; /* Centraliza este item especificamente dentro do flex container */
+    margin: 0 auto;
 
     /* Importante: a largura precisa ser definida pelo JS para que haja espaço para centralizar */
     /* Se você tem um min-height muito grande ou o conteúdo estica o papel, isso pode confundir */

--- a/assets/js/modules/pageSetupModal.js
+++ b/assets/js/modules/pageSetupModal.js
@@ -57,7 +57,7 @@ const applyPageSettingsToEditor = () => {
 
     // AQUI É A PARTE CRÍTICA DO JAVASCRIPT
     // Garante que o container do papel tem a largura máxima do papel
-    elements.paperContainer.style.maxWidth = `${editorWidth}cm`; 
+    elements.paperContainer.style.maxWidth = "100%";
     
     // E que o editor-area DENTRO desse container tenha a largura definida pelo JS,
     // permitindo que margin: auto no CSS centralize-o.


### PR DESCRIPTION
## Summary
- keep the editor centered by letting the container span the page width
- add `margin: 0 auto` to the editor area

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867f260175083219302282074193166