### PR TITLE
Add custom file format export features

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -11,6 +11,7 @@ body {
     align-items: flex-start;
     min-height: 100vh;
     overflow-y: auto; /* Permite rolar a página inteira se o conteúdo for maior que a tela */
+    overflow-x: hidden; /* Evita barra horizontal indesejada */
 }
 
 .app-container {
@@ -61,7 +62,8 @@ body {
     outline: 1px solid #007bff;
 }
 
-.file-actions button {
+.file-actions button,
+.file-actions .file-upload-label {
     background-color: transparent;
     border: 1px solid #ccc;
     padding: 6px 12px;
@@ -75,10 +77,15 @@ body {
     gap: 5px;
 }
 
-.file-actions button:hover {
+.file-actions button:hover,
+.file-actions .file-upload-label:hover {
     background-color: #e6f7ff;
     border-color: #007bff;
     color: #007bff;
+}
+
+.file-actions .dropdown {
+    display: inline-block;
 }
 
 /* --- Estilos da Toolbar --- */
@@ -281,6 +288,9 @@ body {
 .paper-container {
     flex-grow: 1;
     overflow-y: auto; /* Permite rolagem interna do papel */
+    overflow-x: auto; /* Exibe scroll horizontal somente dentro do container */
+    width: 100%;
+    box-sizing: border-box;
     padding: 20px; /* Espaçamento ao redor do papel, dentro do container cinza */
     background-color: #f0f2f5; /* Fundo cinza claro que envolve o papel */
     display: flex;
@@ -293,7 +303,7 @@ body {
     box-shadow: 0 0 15px rgba(0,0,0,0.1); /* Sombra para dar profundidade ao papel */
     border-radius: 4px;
     outline: none; /* Remove contorno de foco padrão do navegador */
-    line-height: 1.8;
+    line-height: var(--line-height, 1.8);
     font-size: 16px;
     color: #333;
     cursor: text;
@@ -314,6 +324,7 @@ body {
     /* Em vez disso, confiamos no justify-content: center do PARENT (.paper-container)
        e garantimos que este item seja centralizável como um flex-item */
     align-self: center; /* Centraliza este item especificamente dentro do flex container */
+    margin: 0 auto;
 
     /* Importante: a largura precisa ser definida pelo JS para que haja espaço para centralizar */
     /* Se você tem um min-height muito grande ou o conteúdo estica o papel, isso pode confundir */
@@ -321,7 +332,7 @@ body {
 
 /* --- Estilos para os elementos editáveis dentro do editor (H1, P, Listas, etc.) --- */
 .editor-area p {
-    margin-bottom: 1em;
+    margin-bottom: var(--paragraph-spacing, 1em);
 }
 
 .editor-area h1, .editor-area h2, .editor-area h3,
@@ -466,4 +477,71 @@ body {
 .form-group input[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.modal-footer button {
+    background-color: transparent;
+    border: 1px solid #ccc;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 14px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+    color: #555;
+}
+
+.modal-footer button:hover {
+    background-color: #e6f7ff;
+    border-color: #007bff;
+    color: #007bff;
+}
+
+.secondary-button {
+    background-color: #f5f5f5;
+}
+/* --- Dropdown para Espaçamento --- */
+.dropdown {
+    position: relative;
+}
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 5px);
+    left: 0;
+    background-color: #ffffff;
+    border: 1px solid #e0e6ed;
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    padding: 5px;
+    z-index: 1100;
+}
+.dropdown-menu.open {
+    display: block;
+}
+.dropdown-menu button {
+    display: block;
+    width: 100%;
+    background-color: transparent;
+    border: none;
+    padding: 6px 10px;
+    text-align: left;
+    cursor: pointer;
+    font-size: 14px;
+    color: #555;
+}
+.dropdown-menu button:hover,
+.dropdown-menu button.active {
+    background-color: #e6f7ff;
+    color: #007bff;
+}
+.dropdown-menu hr {
+    margin: 5px 0;
+    border: 0;
+    border-top: 1px solid #eee;
 }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,22 +1,75 @@
 // assets/js/main.js
 
 import { elements } from './modules/domElements.js';
-import { applyCommand, saveSelection, createLink, insertImage, insertTable } from './modules/commands.js';
-import { newDocument, saveDocument, loadDocument } from './modules/fileManager.js';
+import { applyCommand, saveSelection, openLinkModal, openImageModal, openTableModal, initInsertModals } from './modules/commands.js';
+import {
+    newDocument,
+    saveDocument,
+    loadDocument,
+    exportAsOwd,
+    importFromOwd,
+    exportAsPdf,
+    exportAsDoc,
+    exportAsOdt,
+} from './modules/fileManager.js';
 import { updateToolbarState } from './modules/toolbarState.js';
 import { initColorPickers } from './utils/colorPicker.js';
 import { initPageSetupModal } from './modules/pageSetupModal.js'; // Importa o módulo do modal
+import { initSpacingControls } from './modules/spacingControls.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     // Inicializa todos os módulos
     initColorPickers();
     initPageSetupModal(); // CHAMA APENAS A INICIALIZAÇÃO, NÃO O ABRE DIRETO
+    initSpacingControls();
+    initInsertModals();
 
     // Adiciona ouvintes de evento aos botões e controles (mantido como está)
     // Ações de Arquivo
     elements.newDocBtn.addEventListener('click', newDocument);
     elements.saveDocBtn.addEventListener('click', saveDocument);
     elements.loadDocBtn.addEventListener('click', loadDocument);
+    if (elements.downloadOwdBtn) {
+        elements.downloadOwdBtn.addEventListener('click', exportAsOwd);
+    }
+    if (elements.uploadOwdInput) {
+        elements.uploadOwdInput.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file) importFromOwd(file);
+            e.target.value = '';
+        });
+    }
+    if (elements.exportBtn && elements.exportMenu) {
+        elements.exportBtn.addEventListener('click', () => {
+            elements.exportMenu.classList.toggle('open');
+        });
+        document.addEventListener('click', (ev) => {
+            if (
+                !elements.exportMenu.contains(ev.target) &&
+                !elements.exportBtn.contains(ev.target)
+            ) {
+                elements.exportMenu.classList.remove('open');
+            }
+        });
+    }
+    if (elements.exportPdf) {
+        elements.exportPdf.addEventListener('click', () => {
+            elements.exportMenu.classList.remove('open');
+            exportAsPdf();
+        });
+    }
+    if (elements.exportDoc) {
+        elements.exportDoc.addEventListener('click', () => {
+            elements.exportMenu.classList.remove('open');
+            exportAsDoc();
+        });
+    }
+    if (elements.exportOdt) {
+        elements.exportOdt.addEventListener('click', () => {
+            elements.exportMenu.classList.remove('open');
+            exportAsOdt();
+        });
+    }
 
     // Desfazer/Refazer
     elements.undoBtn.addEventListener('click', () => applyCommand('undo'));
@@ -53,9 +106,9 @@ document.addEventListener('DOMContentLoaded', () => {
     elements.hrBtn.addEventListener('click', () => applyCommand('insertHorizontalRule'));
     elements.unorderedListBtn.addEventListener('click', () => applyCommand('insertUnorderedList'));
     elements.orderedListBtn.addEventListener('click', () => applyCommand('insertOrderedList'));
-    elements.createLinkBtn.addEventListener('click', createLink);
-    elements.insertImageBtn.addEventListener('click', insertImage);
-    elements.insertTableBtn.addEventListener('click', insertTable);
+    elements.createLinkBtn.addEventListener('click', openLinkModal);
+    elements.insertImageBtn.addEventListener('click', openImageModal);
+    elements.insertTableBtn.addEventListener('click', openTableModal);
 
     // Implementa atalhos de teclado (mantido como está)
     elements.editor.addEventListener('keydown', (event) => {
@@ -89,7 +142,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     break;
                 case 'L':
                     event.preventDefault();
-                    createLink();
+                    openLinkModal();
                     break;
                 case '[':
                     event.preventDefault();
@@ -101,11 +154,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     break;
                 case 'p':
                     event.preventDefault();
-                    insertImage();
+                    openImageModal();
                     break;
                 case 't':
                     event.preventDefault();
-                    insertTable();
+                    openTableModal();
                     break;
             }
         }

--- a/assets/js/modules/commands.js
+++ b/assets/js/modules/commands.js
@@ -4,6 +4,11 @@ import { elements } from './domElements.js';
 
 let savedSelectionRange = null; // Para salvar a seleção antes de abrir o pop-up ou executar comandos específicos
 
+const focusActivePage = () => {
+    const last = elements.editor.querySelector('.editor-area:last-child');
+    if (last) last.focus();
+};
+
 // Salva a seleção atual do editor
 export const saveSelection = () => {
     const selection = window.getSelection();
@@ -25,41 +30,102 @@ export const applyCommand = (command, value = null) => {
     }
 
     document.execCommand(command, false, value);
-    elements.editor.focus(); // Mantém o foco no editor
+    focusActivePage(); // Mantém o foco no editor ativo
 };
 
 // Funções para comandos específicos que exigem HTML customizado
-export const insertTable = () => {
-    const rows = prompt('Número de linhas:', '3');
-    const cols = prompt('Número de colunas:', '3');
-    if (rows && cols && !isNaN(rows) && !isNaN(cols)) {
+export const openLinkModal = () => {
+    saveSelection();
+    elements.linkUrl.value = '';
+    elements.linkModal.classList.add('open');
+    elements.linkUrl.focus();
+};
+
+export const openImageModal = () => {
+    saveSelection();
+    elements.imageUrl.value = '';
+    elements.imageModal.classList.add('open');
+    elements.imageUrl.focus();
+};
+
+export const openTableModal = () => {
+    saveSelection();
+    elements.tableRows.value = '3';
+    elements.tableCols.value = '3';
+    elements.tableModal.classList.add('open');
+    elements.tableRows.focus();
+};
+
+const closeModal = (modal) => modal.classList.remove('open');
+
+const insertTableHtml = () => {
+    const rows = parseInt(elements.tableRows.value, 10);
+    const cols = parseInt(elements.tableCols.value, 10);
+    if (rows > 0 && cols > 0) {
         let tableHtml = '<table style="width:100%; border-collapse: collapse;"><tbody>';
-        for (let r = 0; r < parseInt(rows); r++) {
+        for (let r = 0; r < rows; r++) {
             tableHtml += '<tr>';
-            for (let c = 0; c < parseInt(cols); c++) {
-                // Adiciona um estilo básico para a célula e um <br> para facilitar a seleção
+            for (let c = 0; c < cols; c++) {
                 tableHtml += '<td style="border: 1px solid #ccc; padding: 8px;">&nbsp;</td>';
             }
             tableHtml += '</tr>';
         }
         tableHtml += '</tbody></table>';
-        elements.editor.focus();
-        document.execCommand('insertHTML', false, tableHtml);
-    } else {
-        alert('Por favor, insira números válidos para linhas e colunas.');
+        applyCommand('insertHTML', tableHtml);
     }
+    closeModal(elements.tableModal);
 };
 
-export const createLink = () => {
-    const url = prompt('Digite a URL para o link:');
+const insertLinkFromModal = () => {
+    const url = elements.linkUrl.value.trim();
     if (url) {
         applyCommand('createLink', url);
     }
+    closeModal(elements.linkModal);
 };
 
-export const insertImage = () => {
-    const imageUrl = prompt('Digite a URL da imagem:');
-    if (imageUrl) {
-        applyCommand('insertImage', imageUrl);
+const insertImageFromModal = () => {
+    const url = elements.imageUrl.value.trim();
+    if (url) {
+        applyCommand('insertImage', url);
+    }
+    closeModal(elements.imageModal);
+};
+
+export const initInsertModals = () => {
+    if (elements.confirmInsertLink) {
+        elements.confirmInsertLink.addEventListener('click', insertLinkFromModal);
+    }
+    if (elements.cancelInsertLink) {
+        elements.cancelInsertLink.addEventListener('click', () => closeModal(elements.linkModal));
+    }
+    if (elements.linkModal) {
+        const closeBtn = elements.linkModal.querySelector('.close-button');
+        if (closeBtn) closeBtn.addEventListener('click', () => closeModal(elements.linkModal));
+        elements.linkModal.addEventListener('click', (e) => { if (e.target === elements.linkModal) closeModal(elements.linkModal); });
+    }
+
+    if (elements.confirmInsertImage) {
+        elements.confirmInsertImage.addEventListener('click', insertImageFromModal);
+    }
+    if (elements.cancelInsertImage) {
+        elements.cancelInsertImage.addEventListener('click', () => closeModal(elements.imageModal));
+    }
+    if (elements.imageModal) {
+        const closeBtn = elements.imageModal.querySelector('.close-button');
+        if (closeBtn) closeBtn.addEventListener('click', () => closeModal(elements.imageModal));
+        elements.imageModal.addEventListener('click', (e) => { if (e.target === elements.imageModal) closeModal(elements.imageModal); });
+    }
+
+    if (elements.confirmInsertTable) {
+        elements.confirmInsertTable.addEventListener('click', insertTableHtml);
+    }
+    if (elements.cancelInsertTable) {
+        elements.cancelInsertTable.addEventListener('click', () => closeModal(elements.tableModal));
+    }
+    if (elements.tableModal) {
+        const closeBtn = elements.tableModal.querySelector('.close-button');
+        if (closeBtn) closeBtn.addEventListener('click', () => closeModal(elements.tableModal));
+        elements.tableModal.addEventListener('click', (e) => { if (e.target === elements.tableModal) closeModal(elements.tableModal); });
     }
 };

--- a/assets/js/modules/domElements.js
+++ b/assets/js/modules/domElements.js
@@ -6,6 +6,13 @@ export const elements = {
     newDocBtn: document.getElementById('newDocBtn'),
     saveDocBtn: document.getElementById('saveDocBtn'),
     loadDocBtn: document.getElementById('loadDocBtn'),
+    downloadOwdBtn: document.getElementById('downloadOwdBtn'),
+    uploadOwdInput: document.getElementById('uploadOwdInput'),
+    exportBtn: document.getElementById('exportBtn'),
+    exportMenu: document.getElementById('exportMenu'),
+    exportPdf: document.getElementById('exportPdf'),
+    exportDoc: document.getElementById('exportDoc'),
+    exportOdt: document.getElementById('exportOdt'),
 
     // Formatação de Caracteres
     boldBtn: document.getElementById('boldBtn'),
@@ -19,6 +26,12 @@ export const elements = {
     // Controles de Texto/Parágrafo
     formatBlockSelect: document.getElementById('formatBlockSelect'),
     fontSizeSelect: document.getElementById('fontSizeSelect'),
+
+    spacingBtn: document.getElementById('spacingBtn'),
+    spacingMenu: document.getElementById('spacingMenu'),
+    lineOptions: document.querySelectorAll('#spacingMenu .line-option'),
+    increaseSpacing: document.getElementById('increaseSpacing'),
+    decreaseSpacing: document.getElementById('decreaseSpacing'),
 
     // Elementos para os seletores de cor personalizados
     foreColorBtn: document.getElementById('foreColorBtn'),
@@ -66,6 +79,23 @@ export const elements = {
     marginRight: document.getElementById('marginRight'),
     applyPageSetupBtn: document.getElementById('applyPageSetupBtn'),
     cancelPageSetupBtn: document.getElementById('cancelPageSetupBtn'),
+
+    // Modais de Inserção
+    linkModal: document.getElementById('linkModal'),
+    linkUrl: document.getElementById('linkUrl'),
+    confirmInsertLink: document.getElementById('confirmInsertLink'),
+    cancelInsertLink: document.getElementById('cancelInsertLink'),
+
+    imageModal: document.getElementById('imageModal'),
+    imageUrl: document.getElementById('imageUrl'),
+    confirmInsertImage: document.getElementById('confirmInsertImage'),
+    cancelInsertImage: document.getElementById('cancelInsertImage'),
+
+    tableModal: document.getElementById('tableModal'),
+    tableRows: document.getElementById('tableRows'),
+    tableCols: document.getElementById('tableCols'),
+    confirmInsertTable: document.getElementById('confirmInsertTable'),
+    cancelInsertTable: document.getElementById('cancelInsertTable'),
 
     // NOVO: Referência ao paper-container para ajustar maxWidth
     paperContainer: document.querySelector('.paper-container'), // <-- ESTE É IMPORTANTE PARA O LAYOUT

--- a/assets/js/modules/fileManager.js
+++ b/assets/js/modules/fileManager.js
@@ -12,21 +12,102 @@ export const newDocument = () => {
 };
 
 export const saveDocument = () => {
-    const docName = prompt("Digite um nome para o documento:", elements.documentTitle.textContent);
+    const docName = prompt(
+        "Digite um nome para o documento:",
+        elements.documentTitle.textContent
+    );
     if (docName) {
         const documentData = {
             title: docName,
-            content: elements.editor.innerHTML
+            content: elements.editor.innerHTML,
         };
         try {
-            localStorage.setItem(`editor_doc_${docName}`, JSON.stringify(documentData));
+            localStorage.setItem(
+                `editor_doc_${docName}`,
+                JSON.stringify(documentData)
+            );
             elements.documentTitle.textContent = docName;
             alert(`Documento "${docName}" salvo com sucesso!`);
         } catch (e) {
-            alert("Erro ao salvar documento. Armazenamento local pode estar cheio ou desabilitado.");
+            alert(
+                "Erro ao salvar documento. Armazenamento local pode estar cheio ou desabilitado."
+            );
             console.error("Erro ao salvar:", e);
         }
     }
+};
+
+const downloadBlob = (blob, filename) => {
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(link.href);
+};
+
+export const exportAsOwd = () => {
+    const data = {
+        title: elements.documentTitle.textContent,
+        content: elements.editor.innerHTML,
+    };
+    const blob = new Blob([JSON.stringify(data)], {
+        type: 'application/x-openwrite',
+    });
+    const name = `${data.title || 'documento'}.owd`;
+    downloadBlob(blob, name);
+};
+
+export const importFromOwd = (file) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+        try {
+            const data = JSON.parse(e.target.result);
+            if (data && data.content) {
+                elements.editor.innerHTML = data.content;
+                elements.documentTitle.textContent = data.title || 'Documento Sem Título';
+                updateToolbarState();
+            } else {
+                alert('Arquivo inválido.');
+            }
+        } catch (err) {
+            alert('Erro ao ler arquivo.');
+        }
+    };
+    reader.readAsText(file);
+};
+
+export const exportAsPdf = () => {
+    if (!window.jspdf) {
+        alert('Biblioteca jsPDF não carregada.');
+        return;
+    }
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    doc.html(elements.editor, {
+        callback: () => {
+            doc.save(`${elements.documentTitle.textContent || 'documento'}.pdf`);
+        },
+        x: 10,
+        y: 10,
+        width: 180,
+        windowWidth: elements.editor.scrollWidth,
+    });
+};
+
+export const exportAsDoc = () => {
+    const html = `<html><head><meta charset="utf-8"></head><body>${elements.editor.innerHTML}</body></html>`;
+    const blob = new Blob([html], {
+        type: 'application/msword',
+    });
+    downloadBlob(blob, `${elements.documentTitle.textContent || 'documento'}.doc`);
+};
+
+export const exportAsOdt = () => {
+    const html = `<html><head><meta charset="utf-8"></head><body>${elements.editor.innerHTML}</body></html>`;
+    const blob = new Blob([html], {
+        type: 'application/vnd.oasis.opendocument.text',
+    });
+    downloadBlob(blob, `${elements.documentTitle.textContent || 'documento'}.odt`);
 };
 
 export const loadDocument = () => {

--- a/assets/js/modules/pageSetupModal.js
+++ b/assets/js/modules/pageSetupModal.js
@@ -56,12 +56,11 @@ const applyPageSettingsToEditor = () => {
     }
 
     // AQUI É A PARTE CRÍTICA DO JAVASCRIPT
-    // Garante que o container do papel tem a largura máxima do papel
-    elements.paperContainer.style.maxWidth = `${editorWidth}cm`; 
-    
-    // E que o editor-area DENTRO desse container tenha a largura definida pelo JS,
-    // permitindo que margin: auto no CSS centralize-o.
-    elements.editor.style.width = `${editorWidth}cm`; // <--- ATENÇÃO A ESTA LINHA!
+    // Garante que o container do papel ocupe toda a largura disponível
+    // e limita o editor ao tamanho de papel configurado
+    elements.paperContainer.style.maxWidth = '100%';
+    elements.editor.style.width = '100%';
+    elements.editor.style.maxWidth = `${editorWidth}cm`;
 
     elements.editor.style.minHeight = `${editorHeight}cm`; // Altura mínima do papel
 

--- a/assets/js/modules/spacingControls.js
+++ b/assets/js/modules/spacingControls.js
@@ -1,0 +1,89 @@
+import { elements } from './domElements.js';
+
+const defaultSettings = {
+    lineHeight: '1.8',
+    paragraphSpacing: '1em'
+};
+
+let currentSettings = { ...defaultSettings };
+
+const loadSettings = () => {
+    try {
+        const saved = localStorage.getItem('spacingSettings');
+        if (saved) {
+            currentSettings = { ...currentSettings, ...JSON.parse(saved) };
+        }
+    } catch (e) {
+        console.error('Erro ao carregar espaçamentos salvos:', e);
+    }
+};
+
+const saveSettings = () => {
+    try {
+        localStorage.setItem('spacingSettings', JSON.stringify(currentSettings));
+    } catch (e) {
+        console.error('Erro ao salvar espaçamentos:', e);
+    }
+};
+
+const highlightActive = () => {
+    if (elements.lineOptions) {
+        elements.lineOptions.forEach((btn) => {
+            btn.classList.toggle('active', btn.dataset.value === currentSettings.lineHeight);
+        });
+    }
+};
+
+const applySettings = () => {
+    elements.editor.style.setProperty('--line-height', currentSettings.lineHeight);
+    elements.editor.style.setProperty('--paragraph-spacing', currentSettings.paragraphSpacing);
+    if (elements.spacingBtn) elements.spacingBtn.textContent = currentSettings.lineHeight;
+    highlightActive();
+};
+
+export const initSpacingControls = () => {
+    loadSettings();
+    applySettings();
+
+    if (elements.spacingBtn) {
+        elements.spacingBtn.addEventListener('click', () => {
+            if (elements.spacingMenu) elements.spacingMenu.classList.toggle('open');
+        });
+    }
+
+    if (elements.lineOptions) {
+        elements.lineOptions.forEach((btn) => {
+            btn.addEventListener('click', () => {
+                currentSettings.lineHeight = btn.dataset.value;
+                applySettings();
+                saveSettings();
+                if (elements.spacingMenu) elements.spacingMenu.classList.remove('open');
+            });
+        });
+    }
+
+    if (elements.increaseSpacing) {
+        elements.increaseSpacing.addEventListener('click', () => {
+            const value = parseFloat(currentSettings.paragraphSpacing);
+            currentSettings.paragraphSpacing = `${(value + 0.5).toFixed(1)}em`;
+            applySettings();
+            saveSettings();
+        });
+    }
+
+    if (elements.decreaseSpacing) {
+        elements.decreaseSpacing.addEventListener('click', () => {
+            const value = parseFloat(currentSettings.paragraphSpacing);
+            const newValue = Math.max(0, value - 0.5);
+            currentSettings.paragraphSpacing = `${newValue.toFixed(1)}em`;
+            applySettings();
+            saveSettings();
+        });
+    }
+
+    document.addEventListener('click', (e) => {
+        if (!elements.spacingMenu.contains(e.target) && !elements.spacingBtn.contains(e.target)) {
+            elements.spacingMenu.classList.remove('open');
+        }
+    });
+};

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <title>Meu Editor de Documentos</title>
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
     <div class="app-container">
@@ -16,6 +17,17 @@
                     <button id="newDocBtn" title="Novo Documento"><i class="fas fa-file"></i> Novo</button>
                     <button id="saveDocBtn" title="Salvar Documento (Ctrl+S)"><i class="fas fa-save"></i> Salvar</button>
                     <button id="loadDocBtn" title="Abrir Documento"><i class="fas fa-folder-open"></i> Abrir</button>
+                    <button id="downloadOwdBtn" title="Baixar Arquivo"><i class="fas fa-download"></i> Baixar</button>
+                    <label for="uploadOwdInput" class="file-upload-label" title="Carregar Arquivo"><i class="fas fa-upload"></i> Carregar</label>
+                    <input type="file" id="uploadOwdInput" accept=".owd" style="display:none">
+                    <div class="dropdown">
+                        <button id="exportBtn" title="Exportar"><i class="fas fa-share-square"></i> Exportar</button>
+                        <div id="exportMenu" class="dropdown-menu">
+                            <button id="exportPdf">PDF</button>
+                            <button id="exportDoc">Word</button>
+                            <button id="exportOdt">ODF</button>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -97,10 +109,9 @@
                                 <div class="custom-color-row">
                                     <input type="color" class="custom-color-input" value="#FFFF00">
                                     <span>Personalizar</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                </div>
+            </div>
+        </div>
 
                     <div class="toolbar-group">
                         <button id="boldBtn" title="Negrito (Ctrl+B)"><i class="fas fa-bold"></i></button>
@@ -120,7 +131,23 @@
                         <button id="alignLeftBtn" title="Alinhar Esquerda"><i class="fas fa-align-left"></i></button>
                         <button id="alignCenterBtn" title="Alinhar Centro"><i class="fas fa-align-center"></i></button>
                         <button id="alignRightBtn" title="Alinhar Direita"><i class="fas fa-align-right"></i></button>
-                        <button id="alignJustifyBtn" title="Justificar"><i class="fas fa-align-justify"></i></button>
+                    <button id="alignJustifyBtn" title="Justificar"><i class="fas fa-align-justify"></i></button>
+                    </div>
+
+                    <div class="toolbar-group">
+                        <div class="dropdown">
+                            <button id="spacingBtn" title="Espaçamento de Linha"><i class="fas fa-text-height"></i></button>
+                            <div id="spacingMenu" class="dropdown-menu">
+                                <button class="line-option" data-value="1">1</button>
+                                <button class="line-option" data-value="1.15">1.15</button>
+                                <button class="line-option" data-value="1.5">1.5</button>
+                                <button class="line-option" data-value="1.8">1.8</button>
+                                <button class="line-option" data-value="2">2</button>
+                                <hr>
+                                <button id="increaseSpacing">Aumentar Espaço</button>
+                                <button id="decreaseSpacing">Diminuir Espaço</button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="toolbar-group">
@@ -140,12 +167,12 @@
 
         <div class="paper-container">
             <div id="editor" class="editor-area" contenteditable="true" spellcheck="false">
-                <p>Este é o seu novo documento. Digite o conteúdo aqui, assim como você faria em uma folha de papel.</p>
-                <p>Experimente as novas ferramentas e o visual aprimorado!</p>
-                <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
-                <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.</p>
-            </div>
+                    <p>Este é o seu novo documento. Digite o conteúdo aqui, assim como você faria em uma folha de papel.</p>
+                    <p>Experimente as novas ferramentas e o visual aprimorado!</p>
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                    <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem.</p>
+                    <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus id quod maxime placeat facere possimus, omnis voluptas assumenda est, omnis dolor repellendus.</p>
+                </div>
         </div>
     </div>
 
@@ -192,6 +219,61 @@
             <div class="modal-footer">
                 <button id="applyPageSetupBtn">Aplicar</button>
                 <button id="cancelPageSetupBtn" class="secondary-button">Cancelar</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="linkModal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h2>Inserir Link</h2>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="linkUrl">URL:</label>
+                    <input type="text" id="linkUrl">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="confirmInsertLink">Inserir</button>
+                <button id="cancelInsertLink" class="secondary-button">Cancelar</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="imageModal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h2>Inserir Imagem</h2>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="imageUrl">URL da Imagem:</label>
+                    <input type="text" id="imageUrl">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="confirmInsertImage">Inserir</button>
+                <button id="cancelInsertImage" class="secondary-button">Cancelar</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="tableModal" class="modal">
+        <div class="modal-content">
+            <span class="close-button">&times;</span>
+            <h2>Inserir Tabela</h2>
+            <div class="modal-body">
+                <div class="form-group">
+                    <label for="tableRows">Linhas:</label>
+                    <input type="number" id="tableRows" min="1" value="3">
+                </div>
+                <div class="form-group">
+                    <label for="tableCols">Colunas:</label>
+                    <input type="number" id="tableCols" min="1" value="3">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="confirmInsertTable">Inserir</button>
+                <button id="cancelInsertTable" class="secondary-button">Cancelar</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- allow saving custom .owd files and loading them back
- add PDF/Word/ODF export buttons and related DOM hooks
- connect export controls in main script
- style new file action buttons and dropdown
- load jsPDF from CDN for PDF generation

## Testing
- `npm test` *(fails: could not read package.json)*
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_6867f260175083219302282074193166