### PR TITLE
Load html2canvas for PDF export

### DIFF
--- a/assets/js/modules/fileManager.js
+++ b/assets/js/modules/fileManager.js
@@ -77,21 +77,52 @@ export const importFromOwd = (file) => {
     reader.readAsText(file);
 };
 
+const getCleanText = () => {
+    let text = elements.editor.innerText || '';
+    text = text.replace(/\u00A0/g, ' ');
+    text = text.replace(/ {2,}/g, ' ');
+    const lines = text.split(/\r?\n/);
+    const result = [];
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (trimmed === '') {
+            if (result.length && result[result.length - 1] !== '') {
+                result.push('');
+            }
+        } else if (result.length && result[result.length - 1] !== '') {
+            result[result.length - 1] += ' ' + trimmed;
+        } else {
+            result.push(trimmed);
+        }
+    }
+    return result.join('\n\n');
+};
+
 export const exportAsPdf = () => {
     if (!window.jspdf || !window.jspdf.jsPDF) {
         alert('Biblioteca jsPDF não carregada.');
         return;
     }
+    if (!window.html2canvas) {
+        alert('Biblioteca html2canvas não carregada.');
+        return;
+    }
     const doc = new window.jspdf.jsPDF('p', 'pt', 'a4');
+    const tempDiv = document.createElement('div');
+    const cleaned = getCleanText();
+    cleaned.split(/\n{2,}/).forEach((p) => {
+        const para = document.createElement('p');
+        para.textContent = p;
+        tempDiv.appendChild(para);
+    });
 
-    doc.html(elements.editor, {
+    doc.html(tempDiv, {
         callback: () => {
             doc.save(`${elements.documentTitle.textContent || 'documento'}.pdf`);
         },
         x: 40,
         y: 40,
         html2canvas: { scale: 0.8 },
-
     });
 };
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 </head>
 <body>
     <div class="app-container">


### PR DESCRIPTION
## Summary
- load html2canvas from CDN in index.html
- warn if html2canvas is missing when exporting PDFs
- clean editor text before generating PDF to avoid broken lines and extra spaces

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682bd2c3088321928736f60faa18e5