### PR TITLE
Load html2canvas for PDF export

### DIFF
--- a/assets/js/modules/fileManager.js
+++ b/assets/js/modules/fileManager.js
@@ -82,16 +82,23 @@ export const exportAsPdf = () => {
         alert('Biblioteca jsPDF não carregada.');
         return;
     }
-    const doc = new window.jspdf.jsPDF('p', 'pt', 'a4');
+    if (!window.html2canvas) {
+        alert('Biblioteca html2canvas não carregada.');
+        return;
+    }
+
+    const doc = new window.jspdf.jsPDF('p', 'mm', 'a4');
+    const pageWidth = doc.internal.pageSize.getWidth();
 
     doc.html(elements.editor, {
         callback: () => {
             doc.save(`${elements.documentTitle.textContent || 'documento'}.pdf`);
         },
-        x: 40,
-        y: 40,
-        html2canvas: { scale: 0.8 },
-
+        x: 10,
+        y: 10,
+        width: pageWidth - 20,
+        windowWidth: elements.editor.scrollWidth,
+        html2canvas: { scale: 1 },
     });
 };
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="assets/css/style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 </head>
 <body>
     <div class="app-container">


### PR DESCRIPTION
## Summary
- load html2canvas from CDN in index.html
- warn if html2canvas is missing when exporting PDFs
- improve PDF export options so formatting matches the on-screen document

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682bd2c3088321928736f60faa18e5